### PR TITLE
修复成员列表加载错误

### DIFF
--- a/src/components/group/GroupPanel.vue
+++ b/src/components/group/GroupPanel.vue
@@ -108,7 +108,7 @@ function loadMembers() {
     group_id: props.gid,
   }).then(res => {
     if (res.code == 200) {
-      state.members = res.data.items
+      state.members = res.data
     }
   })
 }


### PR DESCRIPTION
按照Go的后端适配的，有可能之前是按照php来的。